### PR TITLE
[ORCA-3475] Make event orchestration team ID a nullable field

### DIFF
--- a/pagerduty/event_orchestration.go
+++ b/pagerduty/event_orchestration.go
@@ -10,15 +10,15 @@ type EventOrchestration struct {
 	ID           string                           `json:"id,omitempty"`
 	Name         string                           `json:"name,omitempty"`
 	Description  string                           `json:"description"`
-	Team         *EventOrchestrationObject        `json:"team,omitempty"`
+	Team         *EventOrchestrationObject        `json:"team"`
 	Routes       int                              `json:"routes,omitempty"`
 	Integrations []*EventOrchestrationIntegration `json:"integrations,omitempty"`
 	// TODO: figure out if we need Updater, Creator / updated_by, created_by, updated_at, created_at, version
 }
 
 type EventOrchestrationObject struct {
-	Type string `json:"type,omitempty"`
-	ID   string `json:"id,omitempty"`
+	Type string  `json:"type,omitempty"`
+	ID   *string `json:"id"`
 }
 
 type EventOrchestrationIntegrationParameters struct {

--- a/pagerduty/event_orchestration_test.go
+++ b/pagerduty/event_orchestration_test.go
@@ -23,6 +23,8 @@ func TestEventOrchestrationTestList(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	tId := "P3ZQXDF"
+
 	want := &ListEventOrchestrationsResponse{
 		Total:  1,
 		Offset: 0,
@@ -35,7 +37,7 @@ func TestEventOrchestrationTestList(t *testing.T) {
 				Description: "bar",
 				Routes:      1,
 				Team: &EventOrchestrationObject{
-					ID: "P3ZQXDF",
+					ID: &tId,
 				},
 			},
 		},
@@ -49,14 +51,15 @@ func TestEventOrchestrationTestList(t *testing.T) {
 func TestEventOrchestrationCreate(t *testing.T) {
 	setup()
 	defer teardown()
-	input := &EventOrchestration{Name: "foo", Description: "bar", Team: &EventOrchestrationObject{ID: "P3ZQXDF"}}
+	tId := "P3ZQXDF"
+	input := &EventOrchestration{Name: "foo", Description: "bar", Team: &EventOrchestrationObject{ID: &tId}}
 
 	mux.HandleFunc(eventOrchestrationBaseUrl, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		v := new(EventOrchestration)
 		v.Name = "foo"
 		v.Description = "bar"
-		v.Team = &EventOrchestrationObject{ID: "P3ZQXDF"}
+		v.Team = &EventOrchestrationObject{ID: &tId}
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
@@ -72,7 +75,7 @@ func TestEventOrchestrationCreate(t *testing.T) {
 	want := &EventOrchestration{
 		Name:        "foo",
 		Description: "bar",
-		Team:        &EventOrchestrationObject{ID: "P3ZQXDF"},
+		Team:        &EventOrchestrationObject{ID: &tId},
 		ID:          "abcd",
 		Routes:      0,
 		Integrations: []*EventOrchestrationIntegration{
@@ -105,10 +108,12 @@ func TestEventOrchestrationGet(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	tId := "P3ZQXDF"
+
 	want := &EventOrchestration{
 		Name:        "foo",
 		Description: "bar",
-		Team:        &EventOrchestrationObject{ID: "P3ZQXDF"},
+		Team:        &EventOrchestrationObject{ID: &tId},
 		ID:          "abcd",
 		Routes:      2,
 		Integrations: []*EventOrchestrationIntegration{
@@ -127,7 +132,8 @@ func TestEventOrchestrationGet(t *testing.T) {
 func TestEventOrchestrationUpdate(t *testing.T) {
 	setup()
 	defer teardown()
-	input := &EventOrchestration{Name: "foo", Description: "bar", Team: &EventOrchestrationObject{ID: "P3ZQXDF"}}
+	tId := "P3ZQXDF"
+	input := &EventOrchestration{Name: "foo", Description: "bar", Team: &EventOrchestrationObject{ID: &tId}}
 	var id = "abcd"
 	var url = fmt.Sprintf("%s/%s", eventOrchestrationBaseUrl, id)
 
@@ -136,7 +142,7 @@ func TestEventOrchestrationUpdate(t *testing.T) {
 		v := new(EventOrchestration)
 		v.Name = "foo"
 		v.Description = "bar"
-		v.Team = &EventOrchestrationObject{ID: "P3ZQXDF"}
+		v.Team = &EventOrchestrationObject{ID: &tId}
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
@@ -152,7 +158,7 @@ func TestEventOrchestrationUpdate(t *testing.T) {
 	want := &EventOrchestration{
 		Name:        "foo",
 		Description: "bar",
-		Team:        &EventOrchestrationObject{ID: "P3ZQXDF"},
+		Team:        &EventOrchestrationObject{ID: &tId},
 		ID:          "abcd",
 		Routes:      2,
 		Integrations: []*EventOrchestrationIntegration{


### PR DESCRIPTION
### Changes
In order to reset the team ID on orchestration the PUT endpoint payload should look like this:
```
{
    "orchestration": { 
        "name": "Orch 1",
        "team": {
            "id": null
        }
    }
}
```
With team.ID being `string` instead of `*string` we couldn't set ID to `nil` (because Go doesn't allow assigning `nil` to variables of type string) and had to use an empty string instead, which is not supported by the API.

This PR makes the team Id property a pointer to the string type that allows us to set it to `nil` when necessary.


### Testing
<img width="470" alt="image" src="https://user-images.githubusercontent.com/47909261/167524920-5683d73a-564d-4c94-bc23-2ff6f0eab799.png">
