### PR TITLE
Remove 'omitempty' from the EventOrchestrationPathSet.Rules property

### DIFF
--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -29,7 +29,7 @@ type EventOrchestrationPathReference struct {
 
 type EventOrchestrationPathSet struct {
 	ID    string                        `json:"id,omitempty"`
-	Rules []*EventOrchestrationPathRule `json:"rules,omitempty"`
+	Rules []*EventOrchestrationPathRule `json:"rules"`
 }
 
 type EventOrchestrationPathRule struct {


### PR DESCRIPTION
### Changes
Remove the `omitempty` tag from the `EventOrchestrationPathSet.Rules` property so we can send Event Orchestration path rules as an empty list