### PR TITLE
Do not drop empty conditions

### DIFF
--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -35,7 +35,7 @@ type EventOrchestrationPathSet struct {
 type EventOrchestrationPathRule struct {
 	ID         string                                 `json:"id,omitempty"`
 	Label      string                                 `json:"label,omitempty"`
-	Conditions []*EventOrchestrationPathRuleCondition `json:"conditions,omitempty"`
+	Conditions []*EventOrchestrationPathRuleCondition `json:"conditions"`
 	Actions    *EventOrchestrationPathRuleActions     `json:"actions,omitempty"`
 	Disabled   bool                                   `json:"disabled,omitempty"`
 }


### PR DESCRIPTION
Remove 'omitempty' from the EventOrchestrationPathSet.Rules.Conditions property