### PR TITLE
[ORCA-3465] - Modify Event Orchestration Path Action Properties

### DIFF
--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -51,7 +51,7 @@ type EventOrchestrationPathRuleCondition struct {
 type EventOrchestrationPathRuleActions struct {
 	RouteTo                    string                                             `json:"route_to,omitempty"`
 	Suppress                   bool                                               `json:"suppress"`
-	Suspend                    int                                                `json:"suspend,omitempty"`
+	Suspend                    *int                                               `json:"suspend"`
 	Priority                   string                                             `json:"priority"`
 	Annotate                   string                                             `json:"annotate"`
 	PagerdutyAutomationActions []*EventOrchestrationPathPagerdutyAutomationAction `json:"pagerduty_automation_actions"`

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -49,7 +49,7 @@ type EventOrchestrationPathRuleCondition struct {
 // Service: https://developer.pagerduty.com/api-reference/179537b835e2d-get-the-service-orchestration-for-a-service
 // Unrouted: https://developer.pagerduty.com/api-reference/70aa1139e1013-get-the-unrouted-orchestration-for-a-global-event-orchestration
 type EventOrchestrationPathRuleActions struct {
-	RouteTo                    string                                             `json:"route_to,omitempty"`
+	RouteTo                    string                                             `json:"route_to"`
 	Suppress                   bool                                               `json:"suppress"`
 	Suspend                    *int                                               `json:"suspend"`
 	Priority                   string                                             `json:"priority"`
@@ -88,7 +88,9 @@ type EventOrchestrationPathActionVariables struct {
 
 type EventOrchestrationPathActionExtractions struct {
 	Target   string `json:"target,omitempty"`
+	Regex string `json:"regex,omitempty"`
 	Template string `json:"template,omitempty"`
+	Source string `json:"source,omitempty"`
 }
 
 type EventOrchestrationPathCatchAll struct {


### PR DESCRIPTION
### Changes:
- remove `omitempty` from E`ventOrchestrationPathRuleActions.RouteTo`
- remove `omitempty` from `EventOrchestrationPathRuleActions.Suspend`, make it `*int`
- add `EventOrchestrationPathActionExtractions.Regex` property
- add `EventOrchestrationPathActionExtractions.Source` property